### PR TITLE
Mentor library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
     - sleep 5
 script: 
     - nyc npm test
-    - sor changemaker.js
+    - sor changemaker.js -r http://localhost:3000
 after_success: 
     - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "6"
 before_script:
     - npm install -g gulp ava nyc coveralls serve
-    - npm link && npm link sor
+    - npm link
     - git clone https://github.com/anyweez/sorjs.com
     - cd sorjs.com && npm install && gulp && node scripts/build_challenges.js
     - serve public &
@@ -11,6 +11,6 @@ before_script:
     - sleep 5
 script: 
     - nyc npm test
-    - node sor.js changemaker.js
+    - sor changemaker.js
 after_success: 
     - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: node_js
 node_js:
     - "6"
 before_script:
-    - npm install -g gulp ava nyc coveralls
+    - npm install -g gulp ava nyc coveralls serve
+    - npm link && npm link sor
+    - git clone https://github.com/anyweez/sorjs.com
+    - cd sorjs.com && npm install && gulp && node scripts/build_challenges.js
+    - serve public &
+    - cd ..
+    - sleep 5
 script: 
     - nyc npm test
     - node sor.js changemaker.js

--- a/mentor/assertion.js
+++ b/mentor/assertion.js
@@ -1,0 +1,5 @@
+/**
+ * Currently the only assertion is 'produces' so it just lives in the core runner module.
+ * This file is a placeholder in case the library of assertions needs to increase in 
+ * complexity (ideally not by much).
+ */

--- a/mentor/reporter.js
+++ b/mentor/reporter.js
@@ -1,0 +1,72 @@
+/**
+ * Report on the outcome of the trials. This generates console output that summarizes 
+ * the output of the trials to the user.
+ */
+const chalk = require('chalk');
+
+const styles = {
+    success_header: chalk.green.bold,
+    success: chalk.green,
+    meh: chalk.yellow,
+    failure_header: chalk.red.bold,
+    failure: chalk.red,
+
+    fyi: chalk.yellow,
+};
+
+module.exports = function (challenge, outcome) {
+    // Print overall summary
+    overall(challenge, outcome);
+
+    // Print per-trial summary
+    outcome.trials.forEach(t => trial(t));
+
+    if (outcome.report.tips.length > 0) {
+        println('Tips:', { color: styles.fyi });
+        outcome.report.tips.forEach(t => tip(t));
+    }
+
+    if (outcome.report.success) {
+        println();
+        println('Good work!', { color: styles.success })
+    }
+};
+
+function tip(t) {
+    println(`* ${t}`, { color: styles.fyi, indent: 1 });
+}
+
+// Print out information about a single trial.
+function trial(t) {
+    const args = t.args.map(arg => JSON.stringify(arg));
+
+    if (t.outcome) {  // success: print short form
+        println(`\u2714  ${t.parent.fn.name}(${args}) => ${JSON.stringify(t.expected)}`, { color: styles.success_header });
+    } else {          // fail: print long form
+        println(`\u2718  ${t.parent.fn.name}(${args})`, { color: styles.failure_header });
+        println(`Expected: ${JSON.stringify(t.expected)}`, { color: styles.failure, indent: 1 });
+        println(`Produced: ${JSON.stringify(t.produced)}`, { color: styles.failure, indent: 1 });
+        println();
+    }
+}
+
+// Print out overall outcome info.
+function overall(challenge, outcome) {
+    const percentage = outcome.report.passed / outcome.report.attempted;
+    let color = undefined;
+
+    if (percentage < 0.5) color = styles.failure;
+    else if (percentage < 1.0) color = styles.meh;
+    else color = styles.success;
+
+    println(`** Progress: ${outcome.report.passed} / ${outcome.report.attempted} passed (${Math.round(percentage * 1000) / 10}%) **`, { color });
+    println();
+}
+
+// Generic print function that handles some styling stuff.
+function println(content = '', {color, indent} = {}) {
+    if (color === undefined) color = chalk.white;
+    if (indent === undefined) indent = 0;
+
+    console.log(color(new Array(indent).fill('    ').join('') + content));
+}

--- a/mentor/runner.js
+++ b/mentor/runner.js
@@ -48,10 +48,28 @@ function Trial(test, args) {
     return this;
 }
 
+// Note: produces() and examine() aren't designed to be used together at this point.
 Trial.prototype.produces = function (expected) { return this._run(expected) };
-Trial.prototype.otherwise = function (msg) { 
-    this.tips.push(msg); 
-    return this; 
+Trial.prototype.examine = function (fn) {
+    try {
+        let { expected, produced } = fn(this.parent.fn.bind(null, ...clone(this.args)));
+        if (expected === undefined || produced === undefined) {
+            throw new Error('value of expected or produced is undefined');
+        }
+
+        this.outcome = expected === produced;
+        this.expected = expected;
+        this.produced = produced;
+
+    } catch (e) {
+        throw new Error(`Tests crashed during examination: ${e.message}`);
+    }
+
+    return this;
+}
+Trial.prototype.otherwise = function (msg) {
+    this.tips.push(msg);
+    return this;
 };
 
 Trial.prototype._run = function (expected) {

--- a/mentor/runner.js
+++ b/mentor/runner.js
@@ -1,0 +1,68 @@
+
+/**
+ * Create a test, which evaluates a single function. The test is a container for 
+ * a bunch of trials, each which evaluates the output of a function based on a 
+ * set of inputs.
+ * 
+ * Running the test produces a report, which can be used by the reporter for
+ * outputting to the screen and the core application for logging, etc.
+ */
+
+const eq = require('lodash').isEqual;
+const clone = require('lodash').cloneDeep;
+
+function Test(fn) {
+    const self = this;
+
+    this.fn = fn;
+    this.trials = [];
+
+    this.report = {
+        get success() { return self.trials.find(trial => trial.outcome === false) === undefined },
+        get attempted() { return self.trials.filter(trial => trial.outcome !== undefined).length },
+        get passed() { return self.trials.filter(trial => trial.outcome).length },
+        get failed() { return self.trials.filter(trial => !trial.outcome).length },
+        get tips() { return [].concat(...self.trials.filter(trial => !trial.outcome).map(trial => trial.tips)) },
+    };
+
+    return this;
+}
+
+Test.prototype.trial = function (...args) {
+    return new Trial(this, args);
+};
+
+function Trial(test, args) {
+    this.parent = test;
+    this.args = args;
+
+    this.parent.trials.push(this);
+
+    // Raw outcome information.
+    this.outcome = undefined;   // todo: make this a getter, get rid of _run?
+    this.expected = undefined;  // expected outcome
+    this.produced = undefined;  // produced outcome
+
+    this.tips = [];
+
+    return this;
+}
+
+Trial.prototype.produces = function (expected) { return this._run(expected) };
+Trial.prototype.otherwise = function (msg) { 
+    this.tips.push(msg); 
+    return this; 
+};
+
+Trial.prototype._run = function (expected) {
+    this.expected = expected;
+    // Clone arguments so that they're effectively immutable from sor's POV.
+    this.produced = this.parent.fn.call(null, ...clone(this.args));
+    this.outcome = eq(this.expected, this.produced);
+
+    return this;
+};
+
+module.exports = {
+    test(fn) { return new Test(fn); }
+};

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
   },
   "homepage": "https://github.com/anyweez/sor#readme",
   "dependencies": {
-    "ava": "^0.15.2",
+    "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "jshint": "^2.9.2",
+    "lodash": "^4.16.4",
     "mz": "^2.4.0",
     "request": "^2.74.0",
     "request-promise": "^4.0.2"
   },
   "devDependencies": {
-    "ava": "^0.16.0",
+    "ava": "^0.15.2",
     "coveralls": "^2.11.12",
     "nyc": "^8.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lodash": "^4.16.4",
     "mz": "^2.4.0",
     "request": "^2.74.0",
-    "request-promise": "^4.0.2"
+    "request-promise": "^4.0.2",
+    "rfr": "^1.2.3"
   },
   "devDependencies": {
     "ava": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Javascript practice problem tool",
   "main": "sor.js",
   "scripts": {

--- a/sor.js
+++ b/sor.js
@@ -5,10 +5,10 @@
  * Returns one if the application runs successfully but at least one test fails. 
  * Returns a number >= 100 if an error occured during execution.
  */
-
 const process = require('process');
 const commander = require('commander');
 const request = require('request-promise');
+const rfr = require('rfr/lib/constants');
 
 commander
     .option('-r, --remote <url>', 'The server to retrieve challenges from')
@@ -20,6 +20,8 @@ if (commander.args.length !== 1) {
     console.error('You must provide a filename.');
     return 100;
 }
+
+process.env.SOR_MENTOR_PATH = `${rfr.defaultRoot}/mentor`;
 
 /**
  * Initialize sorutils with configuration values. Sorutils is where the core

--- a/sor.js
+++ b/sor.js
@@ -27,11 +27,11 @@ if (commander.args.length !== 1) {
  */
 const sorutil = require('./sorutil')({
     // The base URL for requests for challenges
-    baseUrl: `${REMOTE_CHALLENGE_URL}/challenges`,
+    baseUrl: REMOTE_CHALLENGE_URL,
     // The file that the tests should be run on.
-    sorFile: 'sor.target.js',
+    sorFile: `${process.cwd()}/sor.target.js`,
     // The tests that should be run on the sorFile (downloaded from baseUrl)
-    testsFile: 'sor.tests.js',
+    testsFile: `${process.cwd()}/sor.tests.js`,
 });
 
 // The URL to grab the list of available tests from.
@@ -54,8 +54,10 @@ request({ url: REMOTE_CHALLENGES_LIST_URL, headers: { 'User-Agent': 'SorClient' 
         return sorutil.generateFrom(TARGET_FILE, available)
             .then(sorutil.runTests.bind(sorutil))
             .catch(error => {
-                console.error(`${error.type}: ${error.message}`);
+                console.error(`${error.type || 'Unknown error'}: ${error.message}`);
+                console.log(error.stack);
+
                 sorutil._cleanup();
-                process.exit(error.code);
+                process.exit(error.code || 1);
             });
     });

--- a/sor.js
+++ b/sor.js
@@ -53,6 +53,7 @@ request({ url: REMOTE_CHALLENGES_LIST_URL, headers: { 'User-Agent': 'SorClient' 
 
         return sorutil.generateFrom(TARGET_FILE, available)
             .then(sorutil.runTests.bind(sorutil))
+            .then(() => sorutil._cleanup())
             .catch(error => {
                 console.error(`${error.type || 'Unknown error'}: ${error.message}`);
                 console.log(error.stack);

--- a/sor.js
+++ b/sor.js
@@ -8,7 +8,6 @@
 const process = require('process');
 const commander = require('commander');
 const request = require('request-promise');
-const rfr = require('rfr/lib/constants');
 
 commander
     .option('-r, --remote <url>', 'The server to retrieve challenges from')
@@ -20,8 +19,6 @@ if (commander.args.length !== 1) {
     console.error('You must provide a filename.');
     return 100;
 }
-
-process.env.SOR_MENTOR_PATH = `${rfr.defaultRoot}/mentor`;
 
 /**
  * Initialize sorutils with configuration values. Sorutils is where the core

--- a/sorutil.js
+++ b/sorutil.js
@@ -5,10 +5,14 @@ const spawn = require('child_process').spawn;
 const request = require('request-promise');
 const errors = require('./sorerrors');
 
-// TODO: this should respect the --remote setting
-const CONFIRM_URL = 'https://sorjs.com/attempt?';
+const report = require('./mentor/reporter');
+const chalk = require('chalk');
 
 module.exports = function (config) {
+
+    // TODO: this should respect the --remote setting
+    const CONFIRM_URL = `${config.baseUrl}/attempt?`;
+
     return {
         /**
          * Remove all files created by other sorutil operations if they exist.
@@ -19,18 +23,18 @@ module.exports = function (config) {
         },
 
         buildUrl(challenge) {
-            return `${config.baseUrl}/${challenge}.js`
+            return `${config.baseUrl}/challenges/${challenge}.js`
         },
 
         _showChallenge(challenge) {
-            console.log(challenge.title.toUpperCase());
-            console.log(challenge.description.short);
+            console.log(chalk.white.bold(challenge.title.toUpperCase()));
+            console.log(chalk.white(challenge.description.short));
             console.log();
         },
 
         /**
          * Given the provided path, generate the sorfile and download the approriate
-         * test file based on what function is found in the sorFile. Both files should
+         * test file based on what function is found in the sorfile. Both files should
          * exist when the promise returned by this function completes.
          * 
          * `available` is the array of problems available from the server.
@@ -70,7 +74,7 @@ module.exports = function (config) {
                 .then(challenge => {
                     return request({ url: this.buildUrl(challenge.func), headers: { 'User-Agent': 'SorClient' } })
                         .then(tests => {
-                            fs.writeFile(config.testsFile, tests, { encoding: 'utf8' });
+                            fs.writeFileSync(config.testsFile, tests, { encoding: 'utf8' });
                             return challenge;
                         });
                 });
@@ -81,37 +85,18 @@ module.exports = function (config) {
          * assumes that both the sorfile and testfile exist.
          */
         runTests(challenge) {
-            // 4
-            process.env.SOR_RUNNER_DIR = `${__dirname}/node_modules/ava`;
+            /**
+             * Require this file dynamically. Note that this is hard (impossible?) to do with ES6
+             * modules so when the time is right to transition this part will take some refactoring.
+             */
+            const outcome = require(config.testsFile);
+            report(challenge, outcome);
 
-            let tester = spawn(
-                `${__dirname}/node_modules/.bin/ava`,
-                ['--verbose', `${process.cwd()}/${config.testsFile}`],
-                // TODO: Should pass cwd instead of env once this bug is fixed: 
-                // https://github.com/avajs/ava/issues/32
-                { env: process.env }
-            );
-
-            tester.stderr.setEncoding('utf8');
-            tester.stderr.on('data', data => {
-                if (data.trim().length > 0) console.log(data.trim());
-            });
-
-            tester.on('close', code => {
-                console.log();
-                this._cleanup();
-
-                if (code === 0) {
-                    console.log('Successfully ran all tests!');
-                    request({ url: CONFIRM_URL + `challenge=${challenge.func}&success=1`, headers: { 'User-Agent': 'SorClient' } })
-                        .then(() => process.exit(0));
-                }
-                else {
-                    console.error('Error encountered on at least one test.');
-                    request({ url: CONFIRM_URL + `challenge=${challenge.func}&success=0`, headers: { 'User-Agent': 'SorClient' } })
-                        .then(() => process.exit(1));
-                }
-            });
+            // Send a ping to the sorjs server indicating whether the attempt was successful or not.
+            request({
+                url: CONFIRM_URL + `challenge=${challenge.func}&success=${outcome.report.success ? 1 : 0}`,
+                headers: { 'User-Agent': 'SorClient' }
+            }).then(() => process.exit(0));
         }, // end run
     };
 };

--- a/sorutil.js
+++ b/sorutil.js
@@ -5,10 +5,13 @@ const spawn = require('child_process').spawn;
 const request = require('request-promise');
 const errors = require('./sorerrors');
 
+const rfr = require('rfr/lib/constants');
+
 const report = require('./mentor/reporter');
 const chalk = require('chalk');
 
 module.exports = function (config) {
+    process.env.SOR_MENTOR_PATH = `${rfr.defaultRoot}/mentor`;
 
     // TODO: this should respect the --remote setting
     const CONFIRM_URL = `${config.baseUrl}/attempt?`;

--- a/tests/e2e.js
+++ b/tests/e2e.js
@@ -2,11 +2,12 @@ import test from 'ava';
 
 const sorutil = require('../sorutil')({
     // The base URL for requests for challenges
-    baseUrl: 'https://sorjs.com/challenges',
+    // baseUrl: 'https://sorjs.com',
+    baseUrl: 'http://localhost:3000',
     // The file that the tests should be run on.
-    sorFile: 'sor.target.js',
+    sorFile: `${process.cwd()}/sor.target.js`,
     // The tests that should be run on the sorFile (downloaded from baseUrl)
-    testsFile: 'sor.tests.js',
+    testsFile: `${process.cwd()}/sor.tests.js`,
 });
 
 const available = [
@@ -37,6 +38,7 @@ test.serial('runs successfully end-to-end', t => {
         })
         .catch(error => {
             sorutil._cleanup();
+            console.error(error);
             t.fail();
         });
 });

--- a/tests/generateFrom.js
+++ b/tests/generateFrom.js
@@ -1,14 +1,16 @@
 import test from 'ava';
 
-const fs = require('fs');
-const sorutil = require('../sorutil')({
+const config = {
     // The base URL for requests for challenges
-    baseUrl: 'https://sorjs.com/challenges',
+    baseUrl: 'http://localhost:3000',
     // The file that the tests should be run on.
-    sorFile: 'sor.target.js',
+    sorFile: `${process.cwd()}/_sor.target.js`,
     // The tests that should be run on the sorFile (downloaded from baseUrl)
-    testsFile: 'sor.tests.js',
-});
+    testsFile: `${process.cwd()}/_sor.tests.js`,
+};
+
+const fs = require('fs');
+const sorutil = require('../sorutil')(config);
 
 const available = [
     {
@@ -41,8 +43,8 @@ test.serial('can load valid challenge files and generate outputs', t => {
     return sorutil.generateFrom('sample/changemaker.js', available).then(() => {
         // Test to ensure the expected files exist.
         return Promise.all([
-            new Promise(resolve => fs.stat('sor.tests.js', err => resolve(t.is(err, null)))),
-            new Promise(resolve => fs.stat('sor.target.js', err => resolve(t.is(err, null)))),
+            new Promise(resolve => fs.stat(config.testsFile, err => resolve(t.is(err, null)))),
+            new Promise(resolve => fs.stat(config.sorFile, err => resolve(t.is(err, null)))),
         ]);
     }).then(() => sorutil._cleanup());
 });


### PR DESCRIPTION
This PR makes a pretty significant change to the scope of sor by removing ava and instead using a slimmed down custom test library. This feels pretty drastic, but I think it's the right long-term call. Here's my reasoning:
- The limits of ava / tap output are necessarily going to be limiting for anything domain specific (giving hints & tips, highly customized output including results of static analysis, etc).
- The full power and complexity of a modern assertion library is not required. At the moment I've got two assertion-related functions, `produces()` and `examine()`. I hope it can stay about this small or _slightly_ larger, and that this will reduce the contributor learning curve without sacrificing much power.
- Using ava required spawning a new process, and then ava itself spawned additional processes. This made running tests unnecessarily slow.

The mentor library has a few important design decisions that I think will pay off in our context. First, each test has access to the function (singular) that it's testing, meaning that we can do anything related to the function itself, not just its output. At the moment I'm using the name of the function in several places but we could also potentially do some static analysis tasks for more complex feedback. Second, it has first-class support for hints when users fail a particular test case. Third, it has an extremely simple API: the `produces()` function is used for simply checking input against output, and the `examine()` function is a bit more complex but basically provides direct access to the (bound) function itself and allows for custom testing of any sort.
