### PR TITLE
Update pings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "sor.js",
   "scripts": {
     "test": "ava --serial tests/*.js",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "postinstall": "node -e \"console.log(JSON.stringify({ id: Math.round(Math.random() * Number.MAX_SAFE_INTEGER) }))\" > profile.json"
   },
   "bin": {
     "sor": "./sor.js"

--- a/sorutil.js
+++ b/sorutil.js
@@ -10,6 +10,8 @@ const rfr = require('rfr/lib/constants');
 const report = require('./mentor/reporter');
 const chalk = require('chalk');
 
+const SOR_VERSION = require('./package.json').version;
+
 module.exports = function (config) {
     process.env.SOR_MENTOR_PATH = `${rfr.defaultRoot}/mentor`;
 
@@ -26,7 +28,7 @@ module.exports = function (config) {
         },
 
         buildUrl(challenge) {
-            return `${config.baseUrl}/challenges/${challenge}.js`
+            return `${config.baseUrl}/challenges/${challenge}.js?v=${SOR_VERSION}`
         },
 
         _showChallenge(challenge) {
@@ -97,7 +99,7 @@ module.exports = function (config) {
 
             // Send a ping to the sorjs server indicating whether the attempt was successful or not.
             request({
-                url: CONFIRM_URL + `challenge=${challenge.func}&success=${outcome.report.success ? 1 : 0}`,
+                url: CONFIRM_URL + `challenge=${challenge.func}&v=${SOR_VERSION}&success=${outcome.report.success ? 1 : 0}`,
                 headers: { 'User-Agent': 'SorClient' }
             }).then(() => process.exit(0));
         }, // end run

--- a/sorutil.js
+++ b/sorutil.js
@@ -11,6 +11,7 @@ const report = require('./mentor/reporter');
 const chalk = require('chalk');
 
 const SOR_VERSION = require('./package.json').version;
+const profile = require('./profile.json');
 
 module.exports = function (config) {
     process.env.SOR_MENTOR_PATH = `${rfr.defaultRoot}/mentor`;
@@ -28,7 +29,7 @@ module.exports = function (config) {
         },
 
         buildUrl(challenge) {
-            return `${config.baseUrl}/challenges/${challenge}.js?v=${SOR_VERSION}`
+            return `${config.baseUrl}/challenges/${challenge}.js?v=${SOR_VERSION}&user=${profile.id}`
         },
 
         _showChallenge(challenge) {
@@ -99,7 +100,7 @@ module.exports = function (config) {
 
             // Send a ping to the sorjs server indicating whether the attempt was successful or not.
             request({
-                url: CONFIRM_URL + `challenge=${challenge.func}&v=${SOR_VERSION}&success=${outcome.report.success ? 1 : 0}`,
+                url: CONFIRM_URL + `challenge=${challenge.func}&v=${SOR_VERSION}&user=${profile.id}&success=${outcome.report.success ? 1 : 0}`,
                 headers: { 'User-Agent': 'SorClient' }
             }).then(() => process.exit(0));
         }, // end run


### PR DESCRIPTION
This PR fixes #4 and #6, both related to modifying pings that are sent to the sorjs.com servers. Both changes are informational extensions that provide some contextual information about what clients are active and which (anonymous but consistently id'd) users are using them.

Primary reasons for each are:
- Version number: if changes to mentor (#7) come up, will need to be able to route to different test files based on the client version. Could also just add this to the user agent string but I prefer to keep the user agent string stable across versions.
- User ID: need this to experiment around with computing difficulty ratings from logs. Happy to rediscuss if others care later; see details in #4.
